### PR TITLE
Updates for 2017

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title><%= content_for?(:title) ? yield(:title) : "Untitled" %></title>
+    <title><%= content_for?(:title) ? yield(:title) : "Show & Tell" %></title>
 
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application", 'data-turbolinks-track' => true %>

--- a/app/views/shared/_year_menu.erb
+++ b/app/views/shared/_year_menu.erb
@@ -2,6 +2,7 @@
   <div class="large-6 columns">
     <ol class="menu">
       <li><%= link_to 'All', root_path %></li>
+      <li><%= link_to '2017', by_year_path(2017) %></li>
       <li><%= link_to '2016', by_year_path(2016) %></li>
       <li><%= link_to '2015', by_year_path(2015) %></li>
       <li><%= link_to '2014', by_year_path(2014) %></li>

--- a/db/raw_data/speakers.yml
+++ b/db/raw_data/speakers.yml
@@ -1,7 +1,7 @@
 -
   name: Liam
   team: Dev
-  current: true
+  current: false
   external: false
 
 -
@@ -13,7 +13,7 @@
 -
   name: Tom N
   team: Dev
-  current: true
+  current: false
   external: false
 
 -
@@ -35,6 +35,18 @@
   external: false
 
 -
+  name: Tegan
+  team: Dev
+  current: true
+  external: false
+
+-
+  name: Justin K
+  team: Dev
+  current: true
+  external: false
+
+-
   name: David
   team: Dev
   current: false
@@ -49,13 +61,13 @@
 -
   name: Kelv
   team: Dev
-  current: true
+  current: false
   external: false
 
 -
   name: Phil
   team: Dev
-  current: true
+  current: false
   external: false
 
 -
@@ -66,7 +78,7 @@
 
 -
   name: Iris
-  team: Content
+  team: Dev
   current: true
   external: false
 
@@ -79,7 +91,7 @@
 -
   name: Charlotte
   team: Content
-  current: true
+  current: false
   external: false
 
 -
@@ -97,11 +109,29 @@
 -
   name: Paul
   team: Content
-  current: true
+  current: false
   external: false
 
 -
   name: Justin
+  team: Content
+  current: true
+  external: false
+
+-
+  name: Justin O
+  team: Content
+  current: true
+  external: false
+
+-
+  name: Tom D
+  team: Content
+  current: true
+  external: false
+
+-
+  name: Rod
   team: Content
   current: true
   external: false
@@ -210,6 +240,12 @@
 
 -
   name: Joey
+  team: School of Management
+  current: true
+  external: true
+
+-
+  name: Rayner
   team: School of Management
   current: true
   external: true

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -6,6 +6,7 @@ module Scraper
       'https://wiki.bath.ac.uk/display/webservices/Show+and+Tell+2013',
       'https://wiki.bath.ac.uk/display/webservices/Show+and+Tell+2014',
       'https://wiki.bath.ac.uk/display/webservices/Show+and+Tell+2015',
+      'https://wiki.bath.ac.uk/display/webservices/Show+and+Tell+2016',
       'https://wiki.bath.ac.uk/display/webservices/Show+and+Tell+agenda'
     ]
 
@@ -30,6 +31,9 @@ module Scraper
 
       # Skip on if this is a talk from The Future
       next if date > DateTime.current
+
+      # Skip if next item isn't an unordered list
+      next if header.next_element.name != 'ul'
 
       # Gets the contents of each following list item and spits them out
       list = header.next_element.children


### PR DESCRIPTION
- Add link for 2017 stats
- Scrape the new 2016 talks page
- Update speaker seed info 😢
- Skip sessions which have no talks listed due to cancellation or some other reason
- Change default title attribute